### PR TITLE
FileFix‑Style Browser‑Launched Command Execution.kql

### DIFF
--- a/queries/endpoint/FileFix‑Style Browser‑Launched Command Execution.kql
+++ b/queries/endpoint/FileFix‑Style Browser‑Launched Command Execution.kql
@@ -1,0 +1,9 @@
+let MonitoredCommands = dynamic(["powershell", "pwsh", "regsvr32", "bitsadmin", "certutil", "mshta"]);
+let ParentProcessList = dynamic(["chrome", "msedge", "firefox", "brave", "explorer"]);
+DeviceProcessEvents
+| where Timestamp > ago(30d)
+| where FileName has_any(MonitoredCommands)
+| where InitiatingProcessFileName has_any(ParentProcessList)
+| where ProcessCommandLine has_any ("-EncodedCommand", "-enc", "-nop", "-NoProfile", "-w hidden", "-WindowStyle Hidden", "-ExecutionPolicy Bypass", "bypass", "Invoke-WebRequest", "iwr", "DownloadString", "iex", "Invoke-Expression", "Invoke-Obfuscation", "Add-MpPreference", "Start-Process")
+| project Timestamp, DeviceName, FileName, ProcessCommandLine, InitiatingProcessFileName, InitiatingProcessCommandLine, AccountName
+| order by Timestamp desc


### PR DESCRIPTION
FileFix‑Style Browser‑Launched Command Execution.

**Description**
Detects instances where browsers (Chrome, Edge, Firefox, Brave) or Explorer spawn scripting or system binaries with flags commonly used for obfuscation or direct payload retrieval. These indicators align with the FileFix social‑engineering method of tricking users into pasting commands into the File Explorer address bar via a malicious file‑upload page (aka “FileFix Attack”)

**Query**
let MonitoredCommands = dynamic(["powershell", "pwsh", "regsvr32", "bitsadmin", "certutil", "mshta"]);
let ParentProcessList = dynamic(["chrome", "msedge", "firefox", "brave", "explorer"]);
DeviceProcessEvents
| where Timestamp > ago(30d)
| where FileName has_any(MonitoredCommands)
| where InitiatingProcessFileName has_any(ParentProcessList)
| where ProcessCommandLine has_any ("-EncodedCommand", "-enc", "-nop", "-NoProfile", "-w hidden", "-WindowStyle Hidden", "-ExecutionPolicy Bypass", "bypass", "Invoke-WebRequest", "iwr", "DownloadString", "iex", "Invoke-Expression", "Invoke-Obfuscation", "Add-MpPreference", "Start-Process")
| project Timestamp, DeviceName, FileName, ProcessCommandLine, InitiatingProcessFileName, InitiatingProcessCommandLine, AccountName
| order by Timestamp desc