### PR TITLE
Potential Data Exfiltration (Insider Threat).kql

### DIFF
--- a/queries/endpoint/Potential Data Exfiltration (Insider Threat).kql
+++ b/queries/endpoint/Potential Data Exfiltration (Insider Threat).kql
@@ -1,0 +1,42 @@
+// Define personal email domains
+let personalDomains = dynamic(["gmail.com", "yahoo.com", "outlook.com", "hotmail.com", "aol.com", "icloud.com", "protonmail.com"]);
+// Step 1: Get latest disable event per user
+let latestDisables = AuditLogs
+| where OperationName =~ "Disable account"
+| mv-expand TargetResources
+| extend AccountUPN = tostring(TargetResources.userPrincipalName)
+| where isnotempty(AccountUPN)
+| summarize DisabledTime = max(TimeGenerated) by AccountUPN;
+// Step 2: Get last sign-in time per user
+let lastSignIns = SigninLogs
+| summarize LastSignIn = max(TimeGenerated) by UserPrincipalName;
+// Step 3: Join to keep only users who signed in on the same day as being disabled
+let validDisables = latestDisables
+| join kind=inner (
+lastSignIns
+) on $left.AccountUPN == $right.UserPrincipalName
+| where startofday(DisabledTime) == startofday(LastSignIn)
+| project AccountUPN, DisabledTime, LastSignIn;
+// Step 4: Correlate outbound emails to personal domains within 30 days of disable
+EmailEvents
+| where EmailDirection == "Outbound"
+| extend RecipientDomain = tostring(split(RecipientEmailAddress, "@")[1])
+| where RecipientDomain in~ (personalDomains)
+| join kind=inner (
+validDisables
+) on $left.SenderFromAddress == $right.AccountUPN
+| where TimeGenerated between (DisabledTime -30d .. DisabledTime)
+| extend DaysBeforeDisable = datetime_diff('day', DisabledTime, TimeGenerated)
+| summarize
+AttachmentsSent = countif(AttachmentCount > 0),
+TotalEmailsSent = count(),
+FirstSeen = min(TimeGenerated),
+LastSeen = max(TimeGenerated),
+ActiveDays = dcount(bin(TimeGenerated, 1d)),
+PersonalDomainsContacted = make_set(RecipientDomain)
+by UserPrincipalName = SenderFromAddress, DisabledTime, LastSignIn
+| extend
+DaysBeforeDisableStart = datetime_diff('day', DisabledTime, FirstSeen),
+ActivityDurationDays = datetime_diff('day', LastSeen, FirstSeen)
+| where AttachmentsSent > 0
+| sort by TotalEmailsSent desc


### PR DESCRIPTION
Potential Data Exfiltration (Insider Threat)

**Description**
This query is designed to detect potentially malicious data exfiltration by users who were recently disabled, particularly focusing on emails sent to personal email domains (like Gmail, Yahoo, etc.) before the account was disabled. This will be helpful in investigating departing or disabled users who may have sent sensitive data (especially with attachments) to personal email accounts within the 30 days prior to their account being disabled.

**Query**
// Define personal email domains
let personalDomains = dynamic(["[gmail.com](http://gmail.com/)", "[yahoo.com](http://yahoo.com/)", "[outlook.com](http://outlook.com/)", "[hotmail.com](http://hotmail.com/)", "[aol.com](http://aol.com/)", "[icloud.com](http://icloud.com/)", "[protonmail.com](http://protonmail.com/)"]);
// Step 1: Get latest disable event per user
let latestDisables = AuditLogs
| where OperationName =~ "Disable account"
| mv-expand TargetResources
| extend AccountUPN = tostring(TargetResources.userPrincipalName)
| where isnotempty(AccountUPN)
| summarize DisabledTime = max(TimeGenerated) by AccountUPN;
// Step 2: Get last sign-in time per user
let lastSignIns = SigninLogs
| summarize LastSignIn = max(TimeGenerated) by UserPrincipalName;
// Step 3: Join to keep only users who signed in on the same day as being disabled
let validDisables = latestDisables
| join kind=inner (
lastSignIns
) on $left.AccountUPN == $right.UserPrincipalName
| where startofday(DisabledTime) == startofday(LastSignIn)
| project AccountUPN, DisabledTime, LastSignIn;
// Step 4: Correlate outbound emails to personal domains within 30 days of disable
EmailEvents
| where EmailDirection == "Outbound"
| extend RecipientDomain = tostring(split(RecipientEmailAddress, "@")[1])
| where RecipientDomain in~ (personalDomains)
| join kind=inner (
validDisables
) on $left.SenderFromAddress == $right.AccountUPN
| where TimeGenerated between (DisabledTime -30d .. DisabledTime)
| extend DaysBeforeDisable = datetime_diff('day', DisabledTime, TimeGenerated)
| summarize
AttachmentsSent = countif(AttachmentCount > 0),
TotalEmailsSent = count(),
FirstSeen = min(TimeGenerated),
LastSeen = max(TimeGenerated),
ActiveDays = dcount(bin(TimeGenerated, 1d)),
PersonalDomainsContacted = make_set(RecipientDomain)
by UserPrincipalName = SenderFromAddress, DisabledTime, LastSignIn
| extend
DaysBeforeDisableStart = datetime_diff('day', DisabledTime, FirstSeen),
ActivityDurationDays = datetime_diff('day', LastSeen, FirstSeen)
| where AttachmentsSent > 0
| sort by TotalEmailsSent desc
